### PR TITLE
Update libsvm specific version for DIIVINE Project

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -68,7 +68,7 @@ Usage:
 
 Dependencies: 
 Steerable Pyramid Toolbox, Download from: http://www.cns.nyu.edu/~eero/steerpyr/
-LibSVM package for MATLAB, Download from: http://www.csie.ntu.edu.tw/~cjlin/libsvm/
+LibSVM package for MATLAB, Download from: https://github.com/gregfreeman/libsvm/tree/new_matlab_interface
 You may need the MATLAB Image Processing Toolbox
 
 Dependencies--


### PR DESCRIPTION
Dear all,

While I was reproducing the DIIVINE algorithm, I found that there were lots of errors w.r.t. the current libsvm package downloaded from `http://www.csie.ntu.edu.tw/~cjlin/libsvm/`. After hours of try, I have found that if we downloaded libsvm from this repo `https://github.com/gregfreeman/libsvm/tree/new_matlab_interface`, the algorithm could work well. 

That's why I hope you guys can update the link of the libsvm repo for the convenience of others. 

Thanks in advance and have a wonderful day!

Best,

Bruce Shuyue Jia 